### PR TITLE
Faster Autoaim, CanRange Tuning

### DIFF
--- a/src/main/deploy/pathplanner/autos/3 (L4).auto
+++ b/src/main/deploy/pathplanner/autos/3 (L4).auto
@@ -7,7 +7,7 @@
         {
           "type": "path",
           "data": {
-            "pathName": "Side L1 Revised"
+            "pathName": "Side L1 3"
           }
         },
         {

--- a/src/main/deploy/pathplanner/autos/4 (L4).auto
+++ b/src/main/deploy/pathplanner/autos/4 (L4).auto
@@ -1,0 +1,183 @@
+{
+  "version": "2025.0",
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": [
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "CR"
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "L4Position"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "shootCoral"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "To Source 4"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "IntakeCoralDrive"
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "BL"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "IntakeCoral"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "L4Position"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "shootCoral"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "To Source 2 4"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "IntakeCoralDrive"
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "BR"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "IntakeCoral"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "L4Position"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "shootCoral"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "to source 3234"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "IntakeCoralDrive"
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "l3"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "shootCoral"
+          }
+        }
+      ]
+    }
+  },
+  "resetOdom": true,
+  "folder": null,
+  "choreoAuto": false
+}

--- a/src/main/deploy/pathplanner/paths/L1 Coral Path 4.path
+++ b/src/main/deploy/pathplanner/paths/L1 Coral Path 4.path
@@ -3,25 +3,25 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 7.1,
-        "y": 6.082
+        "x": 1.351,
+        "y": 7.17
       },
       "prevControl": null,
       "nextControl": {
-        "x": 7.713450545831575,
-        "y": 6.2840066715058285
+        "x": 1.5835135496640282,
+        "y": 7.030664778153987
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 5.025,
-        "y": 5.307
+        "x": 3.881,
+        "y": 5.3
       },
       "prevControl": {
-        "x": 4.764924523968109,
-        "y": 5.2253979358668365
+        "x": 0.8174002928142214,
+        "y": 7.688644815552506
       },
       "nextControl": null,
       "isLocked": false,
@@ -32,7 +32,7 @@
   "constraintZones": [
     {
       "name": "Constraints Zone",
-      "minWaypointRelativePos": 0.8,
+      "minWaypointRelativePos": 0.93,
       "maxWaypointRelativePos": 1.0,
       "constraints": {
         "maxVelocity": 3.0,
@@ -47,8 +47,32 @@
   "pointTowardsZones": [],
   "eventMarkers": [
     {
-      "name": "L4Position",
+      "name": "L3Position",
       "waypointRelativePos": 0,
+      "endWaypointRelativePos": 0.92,
+      "command": {
+        "type": "sequential",
+        "data": {
+          "commands": [
+            {
+              "type": "named",
+              "data": {
+                "name": "IntakeCoral"
+              }
+            },
+            {
+              "type": "named",
+              "data": {
+                "name": "L3Position"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "L4Position",
+      "waypointRelativePos": 0.93,
       "endWaypointRelativePos": 1.0,
       "command": {
         "type": "named",
@@ -59,22 +83,22 @@
     }
   ],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 4.7,
+    "maxAcceleration": 8.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
     "unlimited": false
   },
   "goalEndState": {
-    "velocity": 0,
-    "rotation": -119.99999999999999
+    "velocity": 0.0,
+    "rotation": -59.99999999999999
   },
   "reversed": false,
-  "folder": "three note",
+  "folder": "four note",
   "idealStartingState": {
     "velocity": 0,
-    "rotation": 180.0
+    "rotation": -55.0
   },
-  "useDefaultConstraints": true
+  "useDefaultConstraints": false
 }

--- a/src/main/deploy/pathplanner/paths/Side L1  4.path
+++ b/src/main/deploy/pathplanner/paths/Side L1  4.path
@@ -8,20 +8,20 @@
       },
       "prevControl": null,
       "nextControl": {
-        "x": 7.713450545831575,
-        "y": 6.2840066715058285
+        "x": 7.699887278734009,
+        "y": 6.407179510117563
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 5.025,
-        "y": 5.307
+        "x": 5.313,
+        "y": 5.155
       },
       "prevControl": {
-        "x": 4.764924523968109,
-        "y": 5.2253979358668365
+        "x": 5.087717841152337,
+        "y": 5.046612044465558
       },
       "nextControl": null,
       "isLocked": false,
@@ -48,7 +48,7 @@
   "eventMarkers": [
     {
       "name": "L4Position",
-      "waypointRelativePos": 0,
+      "waypointRelativePos": 0.0,
       "endWaypointRelativePos": 1.0,
       "command": {
         "type": "named",
@@ -71,7 +71,7 @@
     "rotation": -119.99999999999999
   },
   "reversed": false,
-  "folder": "three note",
+  "folder": "four note",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 180.0

--- a/src/main/deploy/pathplanner/paths/Side L1 3 4.path
+++ b/src/main/deploy/pathplanner/paths/Side L1 3 4.path
@@ -71,10 +71,10 @@
     "rotation": -119.99999999999999
   },
   "reversed": false,
-  "folder": "three note",
+  "folder": "four note",
   "idealStartingState": {
     "velocity": 0,
-    "rotation": 180.0
+    "rotation": -119.99999999999999
   },
   "useDefaultConstraints": true
 }

--- a/src/main/deploy/pathplanner/paths/Side L1 Revised 4.path
+++ b/src/main/deploy/pathplanner/paths/Side L1 Revised 4.path
@@ -8,8 +8,8 @@
       },
       "prevControl": null,
       "nextControl": {
-        "x": 7.713450545831575,
-        "y": 6.2840066715058285
+        "x": 7.389818850722341,
+        "y": 6.123927271879764
       },
       "isLocked": false,
       "linkedName": null
@@ -20,8 +20,8 @@
         "y": 5.307
       },
       "prevControl": {
-        "x": 4.764924523968109,
-        "y": 5.2253979358668365
+        "x": 4.773818781111402,
+        "y": 5.275126059166071
       },
       "nextControl": null,
       "isLocked": false,
@@ -29,21 +29,7 @@
     }
   ],
   "rotationTargets": [],
-  "constraintZones": [
-    {
-      "name": "Constraints Zone",
-      "minWaypointRelativePos": 0.8,
-      "maxWaypointRelativePos": 1.0,
-      "constraints": {
-        "maxVelocity": 3.0,
-        "maxAcceleration": 2.0,
-        "maxAngularVelocity": 540.0,
-        "maxAngularAcceleration": 720.0,
-        "nominalVoltage": 12.0,
-        "unlimited": false
-      }
-    }
-  ],
+  "constraintZones": [],
   "pointTowardsZones": [],
   "eventMarkers": [
     {
@@ -71,7 +57,7 @@
     "rotation": -119.99999999999999
   },
   "reversed": false,
-  "folder": "three note",
+  "folder": "four note",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 180.0

--- a/src/main/deploy/pathplanner/paths/To Source 2 4.path
+++ b/src/main/deploy/pathplanner/paths/To Source 2 4.path
@@ -3,25 +3,25 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 7.1,
-        "y": 6.082
+        "x": 3.881,
+        "y": 5.3
       },
       "prevControl": null,
       "nextControl": {
-        "x": 7.713450545831575,
-        "y": 6.2840066715058285
+        "x": 3.1853509076010895,
+        "y": 6.015231365045763
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 5.025,
-        "y": 5.307
+        "x": 1.492,
+        "y": 7.193
       },
       "prevControl": {
-        "x": 4.764924523968109,
-        "y": 5.2253979358668365
+        "x": 2.2445693225161873,
+        "y": 6.563506315459796
       },
       "nextControl": null,
       "isLocked": false,
@@ -32,11 +32,11 @@
   "constraintZones": [
     {
       "name": "Constraints Zone",
-      "minWaypointRelativePos": 0.8,
+      "minWaypointRelativePos": 0.8555555555555555,
       "maxWaypointRelativePos": 1.0,
       "constraints": {
         "maxVelocity": 3.0,
-        "maxAcceleration": 2.0,
+        "maxAcceleration": 3.0,
         "maxAngularVelocity": 540.0,
         "maxAngularAcceleration": 720.0,
         "nominalVoltage": 12.0,
@@ -47,20 +47,20 @@
   "pointTowardsZones": [],
   "eventMarkers": [
     {
-      "name": "L4Position",
-      "waypointRelativePos": 0,
+      "name": "DefaultPosition",
+      "waypointRelativePos": 0.0,
       "endWaypointRelativePos": 1.0,
       "command": {
         "type": "named",
         "data": {
-          "name": "L4Position"
+          "name": "DefaultPosition"
         }
       }
     }
   ],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 4.7,
+    "maxAcceleration": 8.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -68,13 +68,13 @@
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": -119.99999999999999
+    "rotation": -55.0
   },
   "reversed": false,
-  "folder": "three note",
+  "folder": "four note",
   "idealStartingState": {
     "velocity": 0,
-    "rotation": 180.0
+    "rotation": -59.99999999999999
   },
-  "useDefaultConstraints": true
+  "useDefaultConstraints": false
 }

--- a/src/main/deploy/pathplanner/paths/To Source 4.path
+++ b/src/main/deploy/pathplanner/paths/To Source 4.path
@@ -3,25 +3,25 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 7.1,
-        "y": 6.082
+        "x": 5.025,
+        "y": 5.307
       },
       "prevControl": null,
       "nextControl": {
-        "x": 7.713450545831575,
-        "y": 6.2840066715058285
+        "x": 4.796701046706254,
+        "y": 5.67676971264691
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 5.025,
-        "y": 5.307
+        "x": 1.492,
+        "y": 7.193
       },
       "prevControl": {
-        "x": 4.764924523968109,
-        "y": 5.2253979358668365
+        "x": 0.9850255102040817,
+        "y": 7.371889030612244
       },
       "nextControl": null,
       "isLocked": false,
@@ -32,11 +32,11 @@
   "constraintZones": [
     {
       "name": "Constraints Zone",
-      "minWaypointRelativePos": 0.8,
+      "minWaypointRelativePos": 0.7206349206349205,
       "maxWaypointRelativePos": 1.0,
       "constraints": {
         "maxVelocity": 3.0,
-        "maxAcceleration": 2.0,
+        "maxAcceleration": 3.0,
         "maxAngularVelocity": 540.0,
         "maxAngularAcceleration": 720.0,
         "nominalVoltage": 12.0,
@@ -47,20 +47,20 @@
   "pointTowardsZones": [],
   "eventMarkers": [
     {
-      "name": "L4Position",
+      "name": "DefaultPosition",
       "waypointRelativePos": 0,
       "endWaypointRelativePos": 1.0,
       "command": {
         "type": "named",
         "data": {
-          "name": "L4Position"
+          "name": "DefaultPosition"
         }
       }
     }
   ],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 4.7,
+    "maxAcceleration": 8.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -68,13 +68,13 @@
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": -119.99999999999999
+    "rotation": -55.0
   },
   "reversed": false,
-  "folder": "three note",
+  "folder": "four note",
   "idealStartingState": {
     "velocity": 0,
-    "rotation": 180.0
+    "rotation": -119.99999999999999
   },
-  "useDefaultConstraints": true
+  "useDefaultConstraints": false
 }

--- a/src/main/deploy/pathplanner/paths/fourth4.path
+++ b/src/main/deploy/pathplanner/paths/fourth4.path
@@ -3,25 +3,25 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 7.1,
-        "y": 6.082
+        "x": 1.56,
+        "y": 7.26
       },
       "prevControl": null,
       "nextControl": {
-        "x": 7.713450545831575,
-        "y": 6.2840066715058285
+        "x": 2.3048549976332544,
+        "y": 6.585098874143733
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 5.025,
-        "y": 5.307
+        "x": 3.619,
+        "y": 5.148
       },
       "prevControl": {
-        "x": 4.764924523968109,
-        "y": 5.2253979358668365
+        "x": 3.3504194531038043,
+        "y": 5.3942473698496185
       },
       "nextControl": null,
       "isLocked": false,
@@ -32,7 +32,7 @@
   "constraintZones": [
     {
       "name": "Constraints Zone",
-      "minWaypointRelativePos": 0.8,
+      "minWaypointRelativePos": 0.7818791946308725,
       "maxWaypointRelativePos": 1.0,
       "constraints": {
         "maxVelocity": 3.0,
@@ -47,8 +47,19 @@
   "pointTowardsZones": [],
   "eventMarkers": [
     {
-      "name": "L4Position",
+      "name": "L3Position",
       "waypointRelativePos": 0,
+      "endWaypointRelativePos": 0.78,
+      "command": {
+        "type": "named",
+        "data": {
+          "name": "L3Position"
+        }
+      }
+    },
+    {
+      "name": "L4Position",
+      "waypointRelativePos": 0.78,
       "endWaypointRelativePos": 1.0,
       "command": {
         "type": "named",
@@ -59,8 +70,8 @@
     }
   ],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 4.7,
+    "maxAcceleration": 8.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -68,13 +79,13 @@
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": -119.99999999999999
+    "rotation": -59.99999999999999
   },
   "reversed": false,
-  "folder": "three note",
+  "folder": "four note",
   "idealStartingState": {
     "velocity": 0,
-    "rotation": 180.0
+    "rotation": -55.0
   },
-  "useDefaultConstraints": true
+  "useDefaultConstraints": false
 }

--- a/src/main/deploy/pathplanner/paths/l2 right.path
+++ b/src/main/deploy/pathplanner/paths/l2 right.path
@@ -21,7 +21,7 @@
       },
       "prevControl": {
         "x": 2.9837959183673473,
-        "y": 1.7603635204081625
+        "y": 1.7603635204081622
       },
       "nextControl": null,
       "isLocked": false,

--- a/src/main/deploy/pathplanner/paths/l3.path
+++ b/src/main/deploy/pathplanner/paths/l3.path
@@ -3,25 +3,25 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 7.1,
-        "y": 6.082
+        "x": 1.365,
+        "y": 7.185
       },
       "prevControl": null,
       "nextControl": {
-        "x": 7.713450545831575,
-        "y": 6.2840066715058285
+        "x": 1.7623858959027725,
+        "y": 6.732687680807216
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 5.025,
-        "y": 5.307
+        "x": 3.0891581632653065,
+        "y": 4.192889030612244
       },
       "prevControl": {
-        "x": 4.764924523968109,
-        "y": 5.2253979358668365
+        "x": 3.172760624557998,
+        "y": 4.428495966982556
       },
       "nextControl": null,
       "isLocked": false,
@@ -47,8 +47,19 @@
   "pointTowardsZones": [],
   "eventMarkers": [
     {
-      "name": "L4Position",
+      "name": "L3Position",
       "waypointRelativePos": 0,
+      "endWaypointRelativePos": 0.8,
+      "command": {
+        "type": "named",
+        "data": {
+          "name": "L3Position"
+        }
+      }
+    },
+    {
+      "name": "L4Position",
+      "waypointRelativePos": 0.8,
       "endWaypointRelativePos": 1.0,
       "command": {
         "type": "named",
@@ -59,8 +70,8 @@
     }
   ],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 4.7,
+    "maxAcceleration": 8.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -68,13 +79,13 @@
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": -119.99999999999999
+    "rotation": 0.0
   },
   "reversed": false,
-  "folder": "three note",
+  "folder": "four note",
   "idealStartingState": {
     "velocity": 0,
-    "rotation": 180.0
+    "rotation": -55.0
   },
-  "useDefaultConstraints": true
+  "useDefaultConstraints": false
 }

--- a/src/main/deploy/pathplanner/paths/to source 3234.path
+++ b/src/main/deploy/pathplanner/paths/to source 3234.path
@@ -3,25 +3,25 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 7.1,
-        "y": 6.082
+        "x": 3.619,
+        "y": 5.148
       },
       "prevControl": null,
       "nextControl": {
-        "x": 7.713450545831575,
-        "y": 6.2840066715058285
+        "x": 2.8926959065664386,
+        "y": 5.883360564925911
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 5.025,
-        "y": 5.307
+        "x": 1.365,
+        "y": 7.185
       },
       "prevControl": {
-        "x": 4.764924523968109,
-        "y": 5.2253979358668365
+        "x": 2.128731809388137,
+        "y": 6.527927432990367
       },
       "nextControl": null,
       "isLocked": false,
@@ -29,38 +29,24 @@
     }
   ],
   "rotationTargets": [],
-  "constraintZones": [
-    {
-      "name": "Constraints Zone",
-      "minWaypointRelativePos": 0.8,
-      "maxWaypointRelativePos": 1.0,
-      "constraints": {
-        "maxVelocity": 3.0,
-        "maxAcceleration": 2.0,
-        "maxAngularVelocity": 540.0,
-        "maxAngularAcceleration": 720.0,
-        "nominalVoltage": 12.0,
-        "unlimited": false
-      }
-    }
-  ],
+  "constraintZones": [],
   "pointTowardsZones": [],
   "eventMarkers": [
     {
-      "name": "L4Position",
+      "name": "DefaultPosition",
       "waypointRelativePos": 0,
       "endWaypointRelativePos": 1.0,
       "command": {
         "type": "named",
         "data": {
-          "name": "L4Position"
+          "name": "DefaultPosition"
         }
       }
     }
   ],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 4.7,
+    "maxAcceleration": 8.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -68,13 +54,13 @@
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": -119.99999999999999
+    "rotation": -55.0
   },
   "reversed": false,
-  "folder": "three note",
+  "folder": "four note",
   "idealStartingState": {
     "velocity": 0,
-    "rotation": 180.0
+    "rotation": -59.99999999999999
   },
-  "useDefaultConstraints": true
+  "useDefaultConstraints": false
 }

--- a/src/main/deploy/pathplanner/settings.json
+++ b/src/main/deploy/pathplanner/settings.json
@@ -4,8 +4,9 @@
   "holonomicMode": true,
   "pathFolders": [
     "GoToHP Paths- From Start Zones",
-    "three note",
-    "Two Note"
+    "four note",
+    "Two Note",
+    "three note"
   ],
   "autoFolders": [],
   "defaultMaxVel": 3.0,

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -64,13 +64,13 @@ public final class Constants {
   public static class CameraConstants {
     public static AprilTagFieldLayout aprilTagLayout =
         AprilTagFieldLayout.loadField(AprilTagFields.k2025ReefscapeWelded);
-    public static final Transform3d bowPose =
+    public static final Transform3d starboardPose =
         new Transform3d(
             new Translation3d(
                 Units.inchesToMeters(13.5), Units.inchesToMeters(0), Units.inchesToMeters(7)),
             new Rotation3d(0, -Units.degreesToRadians(15), Units.degreesToRadians(0)));
 
-    public static final Transform3d starboardPose =
+    public static final Transform3d bowPose =
         new Transform3d(
             new Translation3d(
                 Units.inchesToMeters(13.5), Units.inchesToMeters(6.5), Units.inchesToMeters(7)),
@@ -156,9 +156,10 @@ public final class Constants {
   public static class MotorIDConstants {
     public static final int END_EFFECTOR_MOTOR_ID = 2;
     public static final int INTAKE_MOTOR_ID = 1;
-    public static final int CLIMBER_MOTOR_ID1 = 3;
-    public static final int CLIMBER_MOTOR_ID2 = 4;
-    public static final int PIVOT_MOTOR_ID = 5;
+    public static final int CLIMBER_TOP_MOTOR_ID = 5;
+    public static final int CLIMBER_MOTOR_ID1 = 4;
+    public static final int CLIMBER_MOTOR_ID2 = 6;
+    // public static final int PIVOT_MOTOR_ID = 5;
 
     public static final int ELEVATOR_MOTOR_ID1 = 9;
     public static final int ELEVATOR_MOTOR_ID2 = 10;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -576,18 +576,27 @@ public class RobotContainer {
                 .andThen(elevator.executePreset(ElevatorState.Default).withTimeout(0.75))
                 .unless(() -> intake.isCoralIn()));
 
-    operatorButtonBox.button(Constants.ButtonBoxIds.ABORT.getButtonID()).onTrue(elevator.toggle());
-
+    operatorButtonBox
+        .button(Constants.ButtonBoxIds.ABORT.getButtonID())
+        .onTrue(
+            elevator
+                .toggle()
+                .alongWith(
+                    Commands.runOnce(
+                        () -> {
+                          selectedElevatorState = ElevatorState.Default;
+                          Logger.recordOutput("selectedState", selectedElevatorState);
+                        })));
     coralFound.and(() -> DriverStation.isTeleopEnabled()).whileTrue(endEffector.runEffector(2));
 
     canRangeLeft
         .whileTrue(
-            led.setColor(Color.BLUE)
+            led.setColor(Color.YELLOW)
                 .alongWith(new InstantCommand(() -> SmartDashboard.putBoolean("Left", true))))
         .whileFalse(new InstantCommand(() -> SmartDashboard.putBoolean("Left", false)));
     canRangeRight
         .whileTrue(
-            led.setColor(Color.YELLOW)
+            led.setColor(Color.RED)
                 .alongWith(new InstantCommand(() -> SmartDashboard.putBoolean("Right", true))))
         .whileFalse(new InstantCommand(() -> SmartDashboard.putBoolean("Right", false)));
     canRangeMiddle
@@ -598,6 +607,8 @@ public class RobotContainer {
             led.setColor(Color.MAGENTA)
                 .alongWith(new InstantCommand(() -> SmartDashboard.putBoolean("Locked", true))))
         .whileFalse(new InstantCommand(() -> SmartDashboard.putBoolean("Locked", false)));
+    canRangeLeft.and(canRangeMiddle).whileTrue(led.setColor(Color.YELLOW));
+    canRangeRight.and(canRangeMiddle).whileTrue(led.setColor(Color.RED));
   }
 
   public Command getAutonomousCommand() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -255,28 +255,13 @@ public class RobotContainer {
     bargePos = new LoggedDashboardChooser<>("Barge Position", bargePosChooser);
     bargePos.addOption(
         "Barge Left",
-        new AutoDrive(
-            () -> Constants.FieldConstants.RedBargeLeft,
-            drive,
-            () -> alliance.get(),
-            elevator,
-            endEffector));
+        new AutoDrive(() -> Constants.FieldConstants.RedBargeLeft, drive, () -> alliance.get()));
     bargePos.addOption(
         "Barge Middle",
-        new AutoDrive(
-            () -> Constants.FieldConstants.RedBargeMiddle,
-            drive,
-            () -> alliance.get(),
-            elevator,
-            endEffector));
+        new AutoDrive(() -> Constants.FieldConstants.RedBargeMiddle, drive, () -> alliance.get()));
     bargePos.addOption(
         "Barge Right",
-        new AutoDrive(
-            () -> Constants.FieldConstants.RedBargeMiddle,
-            drive,
-            () -> alliance.get(),
-            elevator,
-            endEffector));
+        new AutoDrive(() -> Constants.FieldConstants.RedBargeMiddle, drive, () -> alliance.get()));
     // Named commands for pathplanner autos
     NamedCommands.registerCommand(
         "IntakeCoral",
@@ -308,37 +293,13 @@ public class RobotContainer {
         "L4PositionL2",
         elevator.executePreset(ElevatorState.CoralL4).withTimeout(0.7).unless(coralFound));
     NamedCommands.registerCommand(
-        "AL",
-        new AutoDrive(
-            () -> Constants.FieldConstants.REEF_AL,
-            drive,
-            () -> alliance.get(),
-            elevator,
-            endEffector));
+        "AL", new AutoDrive(() -> Constants.FieldConstants.REEF_AL, drive, () -> alliance.get()));
     NamedCommands.registerCommand(
-        "CR",
-        new AutoDrive(
-            () -> Constants.FieldConstants.REEF_CR,
-            drive,
-            () -> alliance.get(),
-            elevator,
-            endEffector));
+        "CR", new AutoDrive(() -> Constants.FieldConstants.REEF_CR, drive, () -> alliance.get()));
     NamedCommands.registerCommand(
-        "BR",
-        new AutoDrive(
-            () -> Constants.FieldConstants.REEF_BR,
-            drive,
-            () -> alliance.get(),
-            elevator,
-            endEffector));
+        "BR", new AutoDrive(() -> Constants.FieldConstants.REEF_BR, drive, () -> alliance.get()));
     NamedCommands.registerCommand(
-        "BL",
-        new AutoDrive(
-            () -> Constants.FieldConstants.REEF_BL,
-            drive,
-            () -> alliance.get(),
-            elevator,
-            endEffector));
+        "BL", new AutoDrive(() -> Constants.FieldConstants.REEF_BL, drive, () -> alliance.get()));
     // Set up auto routines
     autoChooser = new LoggedDashboardChooser<>("Auto Choices", AutoBuilder.buildAutoChooser());
 
@@ -420,22 +381,10 @@ public class RobotContainer {
                 () -> -driverController.getRightX() * Constants.SLOW_MODE_CONSTANT));
     driverController
         .povLeft()
-        .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.SourceL,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+        .onTrue(new AutoDrive(() -> Constants.FieldConstants.SourceL, drive, () -> alliance.get()));
     driverController
         .povRight()
-        .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.SourceR,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+        .onTrue(new AutoDrive(() -> Constants.FieldConstants.SourceR, drive, () -> alliance.get()));
 
     operatorController.povDown().onTrue(elevator.executePreset(ElevatorState.Default));
     operatorController.povLeft().onTrue(elevator.executePreset(ElevatorState.CoralL2));
@@ -453,110 +402,63 @@ public class RobotContainer {
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_AL.getButtonID())
         .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.REEF_AL,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+            new AutoDrive(() -> Constants.FieldConstants.REEF_AL, drive, () -> alliance.get())
+                .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_BL.getButtonID())
         .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.REEF_BL,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+            new AutoDrive(() -> Constants.FieldConstants.REEF_BL, drive, () -> alliance.get())
+                .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_CL.getButtonID())
         .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.REEF_CL,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+            new AutoDrive(() -> Constants.FieldConstants.REEF_CL, drive, () -> alliance.get())
+                .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_DL.getButtonID())
         .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.REEF_DL,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+            new AutoDrive(() -> Constants.FieldConstants.REEF_DL, drive, () -> alliance.get())
+                .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_EL.getButtonID())
         .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.REEF_EL,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+            new AutoDrive(() -> Constants.FieldConstants.REEF_EL, drive, () -> alliance.get())
+                .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_FL.getButtonID())
         .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.REEF_FL,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+            new AutoDrive(() -> Constants.FieldConstants.REEF_FL, drive, () -> alliance.get())
+                .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_AR.getButtonID())
         .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.REEF_AR,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+            new AutoDrive(() -> Constants.FieldConstants.REEF_AR, drive, () -> alliance.get())
+                .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_BR.getButtonID())
         .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.REEF_BR,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+            new AutoDrive(() -> Constants.FieldConstants.REEF_BR, drive, () -> alliance.get())
+                .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_CR.getButtonID())
         .onTrue(
-            new AutoDrive(
-                    () -> Constants.FieldConstants.REEF_CR,
-                    drive,
-                    () -> alliance.get())
+            new AutoDrive(() -> Constants.FieldConstants.REEF_CR, drive, () -> alliance.get())
                 .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_DR.getButtonID())
         .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.REEF_DR,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+            new AutoDrive(() -> Constants.FieldConstants.REEF_DR, drive, () -> alliance.get())
+                .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_ER.getButtonID())
         .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.REEF_ER,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+            new AutoDrive(() -> Constants.FieldConstants.REEF_ER, drive, () -> alliance.get())
+                .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
     operatorButtonBox
         .button(Constants.ButtonBoxIds.REEF_FR.getButtonID())
         .onTrue(
-            new AutoDrive(
-                () -> Constants.FieldConstants.REEF_FR,
-                drive,
-                () -> alliance.get(),
-                elevator,
-                endEffector));
+            new AutoDrive(() -> Constants.FieldConstants.REEF_FR, drive, () -> alliance.get())
+                .alongWith(autoElevatorCommand(() -> selectedElevatorState)));
 
     // operatorButtonBox
     //     .button(Constants.ButtonBoxIds.REEF_AL.getButtonID())

--- a/src/main/java/frc/robot/commands/AutoDrive.java
+++ b/src/main/java/frc/robot/commands/AutoDrive.java
@@ -9,6 +9,9 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer; // <-- Add this at the top
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.drive.Drive;
+import frc.robot.subsystems.elevator.Elevator;
+import frc.robot.subsystems.elevator.ElevatorIO.ElevatorIOInputs.ElevatorState;
+import frc.robot.subsystems.endeffector.EndEffector;
 import java.util.function.Supplier;
 import org.littletonrobotics.junction.Logger;
 
@@ -18,6 +21,7 @@ public class AutoDrive extends Command {
   private PIDController yController = new PIDController(2.5, 0.0, 0.03);
   private PIDController xController = new PIDController(2.5, 0.0, 0.03);
   private Supplier<Pose2d> targetPose;
+  private ElevatorState state;
   private Pose2d flippedPose, targetPose2d;
   private Drive drive;
   private Supplier<DriverStation.Alliance> allaince;
@@ -25,7 +29,9 @@ public class AutoDrive extends Command {
   private final Timer timer = new Timer(); // <-- Add this
 
   public AutoDrive(
-      Supplier<Pose2d> desiredPose, Drive drive, Supplier<DriverStation.Alliance> alliance) {
+      Supplier<Pose2d> desiredPose,
+      Drive drive,
+      Supplier<DriverStation.Alliance> alliance) {
     this.drive = drive;
     this.targetPose = desiredPose;
     this.allaince = alliance;
@@ -69,6 +75,7 @@ public class AutoDrive extends Command {
     Logger.recordOutput("AutoDrive/targetPose", targetPose.get());
     Logger.recordOutput("AutoDrive/robotrelativespeeds", field);
     Logger.recordOutput("AutoDrive/flippedPose", flippedPose);
+    Logger.recordOutput("AutoDrive/state", state);
   }
 
   @Override

--- a/src/main/java/frc/robot/commands/AutoDrive.java
+++ b/src/main/java/frc/robot/commands/AutoDrive.java
@@ -9,17 +9,15 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer; // <-- Add this at the top
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.drive.Drive;
-import frc.robot.subsystems.elevator.Elevator;
 import frc.robot.subsystems.elevator.ElevatorIO.ElevatorIOInputs.ElevatorState;
-import frc.robot.subsystems.endeffector.EndEffector;
 import java.util.function.Supplier;
 import org.littletonrobotics.junction.Logger;
 
 public class AutoDrive extends Command {
 
   private PIDController rotationController = new PIDController(4, 0, 0.02);
-  private PIDController yController = new PIDController(2.5, 0.0, 0.03);
-  private PIDController xController = new PIDController(2.5, 0.0, 0.03);
+  private PIDController yController = new PIDController(3, 0.0, 0.02);
+  private PIDController xController = new PIDController(3, 0.0, 0.02);
   private Supplier<Pose2d> targetPose;
   private ElevatorState state;
   private Pose2d flippedPose, targetPose2d;
@@ -29,9 +27,7 @@ public class AutoDrive extends Command {
   private final Timer timer = new Timer(); // <-- Add this
 
   public AutoDrive(
-      Supplier<Pose2d> desiredPose,
-      Drive drive,
-      Supplier<DriverStation.Alliance> alliance) {
+      Supplier<Pose2d> desiredPose, Drive drive, Supplier<DriverStation.Alliance> alliance) {
     this.drive = drive;
     this.targetPose = desiredPose;
     this.allaince = alliance;

--- a/src/main/java/frc/robot/subsystems/climber/Climber.java
+++ b/src/main/java/frc/robot/subsystems/climber/Climber.java
@@ -7,34 +7,15 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class Climber extends SubsystemBase {
   public final PneumaticHub revPH;
-  public final Solenoid solenoid1, solenoid2, solenoid3;
+  public final Solenoid solenoid2, solenoid3;
   public final ClimberIO io;
 
   public Climber(int portID, ClimberIO io) {
     this.revPH = new PneumaticHub(portID);
-    this.solenoid1 = revPH.makeSolenoid(1);
     this.solenoid2 = revPH.makeSolenoid(4);
     this.solenoid3 = revPH.makeSolenoid(0);
     this.io = io;
     this.setDefaultCommand(defaultCommand());
-  }
-
-  public void extend1() {
-    this.solenoid1.set(true);
-    this.io.setRPM(6);
-  }
-
-  public void retract1() {
-    this.solenoid1.set(false);
-  }
-
-  // Create commands for unwinding and retracting
-  public Command extendCommand1() {
-    return run(this::extend1);
-  }
-
-  public Command retractCommand1() {
-    return run(this::retract1);
   }
 
   public void extend2() {
@@ -48,17 +29,23 @@ public class Climber extends SubsystemBase {
   }
 
   public void default1() {
-    this.solenoid1.set(false);
     this.solenoid2.set(true);
   }
 
-  public void goUp() {
-    retract2();
-    extend1();
+  public Command upGo() {
+    return runOnce(this::retract2);
   }
 
-  public Command upGo() {
-    return run(this::goUp);
+  public Command up() {
+    return this.startEnd(() -> io.setClimbRPM(10), () -> io.setClimbRPM(0));
+  }
+
+  public Command down() {
+    return this.startEnd(() -> io.setClimbRPM(-10), () -> io.setClimbRPM(0));
+  }
+
+  public Command topMotor() {
+    return this.startEnd(() -> io.setTopRPM(6), () -> io.setTopRPM(0));
   }
 
   // Create commands for unwinding and retracting

--- a/src/main/java/frc/robot/subsystems/climber/ClimberIO.java
+++ b/src/main/java/frc/robot/subsystems/climber/ClimberIO.java
@@ -38,6 +38,7 @@ public interface ClimberIO {
   /** Enable or disable brake mode on the intake motor. */
   default void setBrakeMode(boolean enable) {}
 
-  /** the. */
-  default void setRPM(double rpm) {}
+  default void setTopRPM(double rpm) {}
+
+  default void setClimbRPM(double rpm) {}
 }

--- a/src/main/java/frc/robot/subsystems/climber/ClimberIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/climber/ClimberIOTalonFX.java
@@ -15,7 +15,7 @@ import edu.wpi.first.units.measure.Voltage;
 /** the. */
 public class ClimberIOTalonFX implements ClimberIO {
 
-  public final TalonFX motor;
+  public final TalonFX topMotor, climbMotor1, climbMotor2;
   public StatusSignal<Voltage> motorVolts;
   public StatusSignal<Current> motorAmps;
   public StatusSignal<AngularVelocity> motorRPM;
@@ -27,23 +27,31 @@ public class ClimberIOTalonFX implements ClimberIO {
    *
    * @param motorID The ID of the motor.
    */
-  public ClimberIOTalonFX(int motorID) {
-    motor = new TalonFX(motorID);
+  public ClimberIOTalonFX(int topMotorID, int climbID1, int climbID2) {
+    topMotor = new TalonFX(topMotorID);
+    climbMotor1 = new TalonFX(climbID1);
+    climbMotor2 = new TalonFX(climbID2);
 
     // Configure motor
     TalonFXConfiguration motorConfig = new TalonFXConfiguration();
     motorConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
     motorConfig.MotorOutput.Inverted = InvertedValue.CounterClockwise_Positive;
 
+    TalonFXConfiguration motorConfig2 = new TalonFXConfiguration();
+    motorConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
+    motorConfig.MotorOutput.Inverted = InvertedValue.Clockwise_Positive;
+
     // Configure the integrated encoder (default settings should work)
-    motor.getConfigurator().apply(motorConfig);
+    topMotor.getConfigurator().apply(motorConfig);
+    climbMotor1.getConfigurator().apply(motorConfig);
+    climbMotor2.getConfigurator().apply(motorConfig2);
     motorConfig.MotorOutput.Inverted = InvertedValue.CounterClockwise_Positive;
-    motorVolts = motor.getMotorVoltage();
-    motorAmps = motor.getStatorCurrent();
-    motorRPM = motor.getVelocity();
+    motorVolts = topMotor.getMotorVoltage();
+    motorAmps = topMotor.getStatorCurrent();
+    motorRPM = topMotor.getVelocity();
 
     BaseStatusSignal.setUpdateFrequencyForAll(50.0, motorVolts, motorAmps, motorRPM);
-    ParentDevice.optimizeBusUtilizationForAll(motor);
+    ParentDevice.optimizeBusUtilizationForAll(topMotor);
   }
 
   @Override
@@ -63,11 +71,17 @@ public class ClimberIOTalonFX implements ClimberIO {
   public void setBrakeMode(boolean enable) {}
 
   @Override
-  public void setRPM(double voltage) {
-    motor.setVoltage(MathUtil.clamp(voltage, -12.0, 12.0));
+  public void setTopRPM(double voltage) {
+    topMotor.setVoltage(MathUtil.clamp(voltage, -12.0, 12.0));
+  }
+
+  @Override
+  public void setClimbRPM(double voltage) {
+    climbMotor1.setVoltage(MathUtil.clamp(voltage, -12.0, 12.0));
+    climbMotor2.setVoltage(MathUtil.clamp(voltage, -12.0, 12.0));
   }
 
   public double getPosition() {
-    return motor.getPosition().getValueAsDouble();
+    return topMotor.getPosition().getValueAsDouble();
   }
 }

--- a/src/main/java/frc/robot/subsystems/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/elevator/Elevator.java
@@ -21,6 +21,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.subsystems.elevator.ElevatorIO.ElevatorIOInputs;
 import frc.robot.subsystems.elevator.ElevatorIO.ElevatorIOInputs.ElevatorState;
+import java.util.function.Supplier;
 import org.littletonrobotics.junction.Logger;
 
 /**
@@ -120,6 +121,28 @@ public class Elevator extends SubsystemBase {
     return run(() -> this.setPreset(state));
   }
 
+  public Command executePreset(Supplier<ElevatorState> supplier) {
+    Logger.recordOutput("state: ", supplier.get());
+    return run(() -> this.setPreset(supplier.get()));
+  }
+
+  // public Command runBufferedPreset() {
+  //   Logger.recordOutput("Elevator/BufferedState", bufferedState.getEncoderPosition());
+  //   if (bufferedState.getEncoderPosition() == ElevatorState.CoralL1.getEncoderPosition()) {
+  //     return executePreset(ElevatorState.CoralL1);
+  //   } else if (bufferedState.getEncoderPosition() == ElevatorState.CoralL2.getEncoderPosition())
+  // {
+  //     return executePreset(ElevatorState.CoralL2);
+  //   } else if (bufferedState.getEncoderPosition() == ElevatorState.CoralL3.getEncoderPosition())
+  // {
+  //     return executePreset(ElevatorState.CoralL3);
+  //   } else if (bufferedState.getEncoderPosition() == ElevatorState.CoralL4.getEncoderPosition())
+  // {
+  //     return executePreset(ElevatorState.CoralL4);
+  //   }
+  //   return executePreset(ElevatorState.Default);
+  // }
+
   public void setBrakeMode() {
     io.setBrakeMode();
   }
@@ -157,5 +180,14 @@ public class Elevator extends SubsystemBase {
    */
   public ElevatorState getElevatorState() {
     return inputs.elevatorState;
+  }
+
+  /** Toggles toggle. */
+  public Command toggle() {
+    return this.runOnce(io::switchToggle);
+  }
+
+  public boolean getToggle() {
+    return inputs.toggle;
   }
 }

--- a/src/main/java/frc/robot/subsystems/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/elevator/Elevator.java
@@ -126,23 +126,6 @@ public class Elevator extends SubsystemBase {
     return run(() -> this.setPreset(supplier.get()));
   }
 
-  // public Command runBufferedPreset() {
-  //   Logger.recordOutput("Elevator/BufferedState", bufferedState.getEncoderPosition());
-  //   if (bufferedState.getEncoderPosition() == ElevatorState.CoralL1.getEncoderPosition()) {
-  //     return executePreset(ElevatorState.CoralL1);
-  //   } else if (bufferedState.getEncoderPosition() == ElevatorState.CoralL2.getEncoderPosition())
-  // {
-  //     return executePreset(ElevatorState.CoralL2);
-  //   } else if (bufferedState.getEncoderPosition() == ElevatorState.CoralL3.getEncoderPosition())
-  // {
-  //     return executePreset(ElevatorState.CoralL3);
-  //   } else if (bufferedState.getEncoderPosition() == ElevatorState.CoralL4.getEncoderPosition())
-  // {
-  //     return executePreset(ElevatorState.CoralL4);
-  //   }
-  //   return executePreset(ElevatorState.Default);
-  // }
-
   public void setBrakeMode() {
     io.setBrakeMode();
   }

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIO.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIO.java
@@ -27,7 +27,7 @@ public interface ElevatorIO {
      */
     public enum ElevatorState {
       Default(0.378),
-      CoralL1(0.7),
+      CoralL1(0.65),
       CoralL2(1.7),
       DealgifyL2(1.5),
       CoralL3(3.95),
@@ -58,6 +58,7 @@ public interface ElevatorIO {
     public boolean elevatorAtSetpoint = false;
     public boolean zeroSwitchTriggered = false;
     public double elevatorMotorPosition = 0.0;
+    public boolean toggle = false;
 
     // Utility method to get the desired encoder position for the current state
     public double getDesiredEncoderPosition() {
@@ -80,6 +81,7 @@ public interface ElevatorIO {
   /** Enable or disable brake mode on the elevator motor. */
   default void setBrakeMode() {}
 
+  /** Set the Elevator to Coast. */
   default void setCoastMode() {}
 
   /** Get if the Limit Switch is triggered. */
@@ -87,4 +89,7 @@ public interface ElevatorIO {
 
   /** Zero the Elevator Encoder. */
   default void zeroElevator() {}
+
+  /** Switch the Toggle State of the Elevator. */
+  default void switchToggle() {}
 }

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIOTalonFX.java
@@ -48,6 +48,7 @@ public class ElevatorIOTalonFX implements ElevatorIO {
   private final StatusSignal<Voltage> motorAppliedVoltsSignal;
   private final StatusSignal<Current> motorCurrentSignal;
   private final StatusSignal<Angle> motorPosition;
+  private boolean toggleSwitch;
 
   private final Debouncer encoderConnectedDebounce = new Debouncer(0.5);
   private final NeutralOut neutralOut = new NeutralOut();
@@ -100,6 +101,7 @@ public class ElevatorIOTalonFX implements ElevatorIO {
     motorAppliedVoltsSignal = elevatorMotor.getMotorVoltage();
     motorCurrentSignal = elevatorMotor.getStatorCurrent();
     motorPosition = elevatorMotor.getPosition();
+    toggleSwitch = false;
 
     BaseStatusSignal.setUpdateFrequencyForAll(
         50.0, encoderPositionSignal, motorAppliedVoltsSignal, motorCurrentSignal, motorPosition);
@@ -121,6 +123,7 @@ public class ElevatorIOTalonFX implements ElevatorIO {
     inputs.elevatorAppliedVolts = motorAppliedVoltsSignal.getValueAsDouble();
     inputs.elevatorCurrentAmps = motorCurrentSignal.getValueAsDouble();
     inputs.elevatorMotorPosition = motorPosition.getValueAsDouble();
+    inputs.toggle = toggleSwitch;
   }
 
   @Override
@@ -160,5 +163,10 @@ public class ElevatorIOTalonFX implements ElevatorIO {
   @Override
   public void zeroElevator() {
     elevatorEncoder.setPosition(0); // Zero the CANcoder encoder
+  }
+
+  @Override
+  public void switchToggle() {
+    toggleSwitch = !toggleSwitch;
   }
 }

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -82,6 +82,10 @@ public class Intake extends SubsystemBase {
     return !inputs.coralSet && inputs.coralIn;
   }
 
+  public boolean inRamp() {
+    return !inputs.coralSet && !inputs.coralIn;
+  }
+
   public boolean canRangeLeftDetected() {
     return inputs.side1IsDetected;
   }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOTalonFX.java
@@ -62,15 +62,15 @@ public class IntakeIOTalonFX implements IntakeIO {
     CANrangeConfiguration sideConfig = new CANrangeConfiguration();
     CANrangeConfiguration middleConfig = new CANrangeConfiguration();
 
-    middleConfig.FovParams.FOVRangeX = 7;
-    middleConfig.ProximityParams.MinSignalStrengthForValidMeasurement = 2000;
-    middleConfig.ProximityParams.ProximityThreshold = 0.52;
+    middleConfig.FovParams.FOVRangeX = 6.75;
+    middleConfig.ProximityParams.MinSignalStrengthForValidMeasurement = 1000;
+    middleConfig.ProximityParams.ProximityThreshold = 0.55;
     middleConfig.ToFParams.UpdateMode = UpdateModeValue.LongRangeUserFreq;
     middleConfig.ToFParams.UpdateFrequency = 50.0;
 
-    sideConfig.FovParams.FOVRangeX = 24;
-    sideConfig.ProximityParams.MinSignalStrengthForValidMeasurement = 2000;
-    sideConfig.ProximityParams.ProximityThreshold = 0.52;
+    sideConfig.FovParams.FOVRangeX = 25;
+    sideConfig.ProximityParams.MinSignalStrengthForValidMeasurement = 1000;
+    sideConfig.ProximityParams.ProximityThreshold = 0.55;
     sideConfig.ToFParams.UpdateMode = UpdateModeValue.LongRangeUserFreq;
     sideConfig.ToFParams.UpdateFrequency = 50.0;
     middleRange.getConfigurator().apply(middleConfig);


### PR DESCRIPTION
- NEW FEATURE: Elevator Raises during Autoaim. Can be toggled on or off using the red button on the button box. TODO: SWITCH THIS POSITION

- LIGHT TUNING: The CANRanges have been tuned such that they are usable in game. However, there are still some tweaks that must be made in order to signal which direction the robot has to move properly.

- TUNING: The PID has been made faster with a P of 3 and a D of .02. One has been increased by 1, and the other decreased by .01.

